### PR TITLE
Merge managing and contributing memberships

### DIFF
--- a/membership.html
+++ b/membership.html
@@ -504,7 +504,7 @@
             </h2>
             <span class="text">By becoming a member, you tell us and the world that you are a part of the PSF and support our work, and as one of the classes of voting members, you add your voice to the future direction of the Foundation. We're so happy to have you!
             <br>
-            To be a supporting, managing, or contributing member (currently) folks must first become a basic member. 
+            To be a supporting or contributing member (currently) folks must first become a basic member.
             </span>
             <br>
             <hr class="gray-25">
@@ -609,7 +609,7 @@
                 <!-- Header -->
                 <div class="card-header pb-0 text-center">
                   <h3 class="title m-0 text-style-11 text-italic white">
-                    <span class="bg-color black">MANAGING / CONTRIBUTING</span>
+                    <span class="bg-color black">CONTRIBUTING</span>
                     <span class="zzz mt-1 mb-1 scheme-2 gray"></span>
                     <br>
                   </h3>
@@ -622,12 +622,7 @@
                 <div class="card-body">
                   <!-- List -->
                   <ul class="checklist">
-                      <span class="text-white">Managing member:</span><br>
-                      <span class="text">Min 5 hrs/month devoted to the community or PSF (Events, Projects, Workgroups)
-                      </span><br>
-                      <br>
-                      <span class="text-white">Contributing member:</span><br>
-                      <span class="text">Min 5 hrs/month devoted to open source projects related to PSF's mission (Create or maintain at no charge)
+                      <span class="text">Min 5 hrs/month volunteering on projects which advance the mission of the PSF by creating or maintaining open source software available to the public at no charge, organizing Python events, participating in one of the PSF's working groups, etc.
                       </span><br>
                       <br>
                         <li class="item">


### PR DESCRIPTION
Last year, PSF managing and contributing membership classes were merged into a single contributing membership:

* https://pyfound.blogspot.com/2024/07/announcing-2024-psf-board-election.html
* https://github.com/psf/bylaws/compare/a35a6071de181adbb7a160d5d1447e7b0272359c...359cbc540f2f6bf00bc46b9dbe3e00a950612c27

This PR updates https://psf.github.io/diversity-and-inclusion-wg/membership.html to refer to just contributing membership, and uses the wording from https://www.python.org/psf/membership/